### PR TITLE
Use updated releases API. Set page-count header to match offender count

### DIFF
--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -19,7 +19,8 @@ module.exports = function(token) {
         getUpcomingReleasesFor: function(nomisIds) {
             const path = url.resolve(`${apiUrl}`, `${apiRoot}/offender-releases`);
             const query = {offenderNo: nomisIds};
-            return nomisGet(path, query, token);
+            const headers = {'Page-Count': nomisIds.length};
+            return nomisGet(path, query, token, headers);
         },
 
         getBookings: function(nomisId) {
@@ -51,7 +52,7 @@ module.exports = function(token) {
     };
 };
 
-async function nomisGet(path, query, token) {
+async function nomisGet(path, query, token, headers = {}) {
 
     try {
         const gwToken = process.env.NODE_ENV === 'test' ? 'dummy' : `Bearer ${generateApiGatewayToken()}`;
@@ -62,6 +63,7 @@ async function nomisGet(path, query, token) {
             .set('Accept', 'application/json')
             .set('Authorization', gwToken)
             .set('Elite-Authorization', token)
+            .set(headers)
             .timeout(timeoutSpec);
 
         return result.body;

--- a/server/views/tasklist/index.pug
+++ b/server/views/tasklist/index.pug
@@ -29,8 +29,8 @@ block content
                                     | #{entry.offenderNo}
 
                             td.requiredEstablishment
-                                if entry.assignedLivingUnit && entry.assignedLivingUnit.description
-                                    | #{entry.assignedLivingUnit.description}
+                                if entry.agencyLocationDesc
+                                    | #{entry.agencyLocationDesc}
 
                             td.requiredDischargeDate
                                 if entry.releaseDate

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -27,9 +27,24 @@ describe('nomisClient', function() {
             return expect(nomisClient.getUpcomingReleasesFor('a', 'token')).to.eventually.eql({key: 'value'});
         });
 
+        it('should set the page-count header to match the number of offenders', () => {
+            fakeNomis
+                .get(`/${config.nomis.apiRoot}/offender-releases?offenderNo=a&offenderNo=b&offenderNo=c`)
+                .reply(function(uri, requestBody) {
+                    // The documented way to specify request headers doesn't work so this is a workaround
+                    if (this.req.headers['page-count'] === 3) { // eslint-disable-line
+                        return 200, {key: 'value'};
+                    }
+                    return null;
+                });
+
+            return expect(nomisClient.getUpcomingReleasesFor(['a', 'b', 'c'], 'token'))
+                .to.eventually.eql({key: 'value'});
+        });
+
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/releases?offenderNo=a`)
+                .get(`/${config.nomis.apiRoot}/offender-releases?offenderNo=a`)
                 .reply(500);
 
             return expect(nomisClient.getUpcomingReleasesFor('a', 'token')).to.be.rejected();


### PR DESCRIPTION
Struggled for bloody ages to get nock to obey request header settings and it just doesn't work the way it's documented, so there's an ugly alternative. 

See corresponding nomis mock PR