### PR TITLE
Fix paths for elite2 api calls

### DIFF
--- a/server/authentication/signIn.js
+++ b/server/authentication/signIn.js
@@ -1,5 +1,4 @@
 const superagent = require('superagent');
-const url = require('url');
 const config = require('../config');
 const generateApiGatewayToken = require('./apiGateway');
 const logger = require('../../log');
@@ -9,9 +8,8 @@ async function signIn(username, password) {
     logger.info(`Log in for: ${username}`);
 
     try {
-
         const loginResult = await superagent
-            .post(url.resolve(`${config.nomis.apiUrl}`, `/${config.nomis.apiRoot}/users/login`))
+            .post(`${config.nomis.apiUrl}/users/login`)
             .set('Authorization', `Bearer ${generateApiGatewayToken()}`)
             .send({username, password})
             .timeout({response: 2000, deadline: 2500});
@@ -20,7 +18,7 @@ async function signIn(username, password) {
         const eliteAuthorisationToken = loginResult.body.token;
 
         const profileResult = await superagent
-            .get(url.resolve(`${config.nomis.apiUrl}`, `/${config.nomis.apiRoot}/users/me`))
+            .get(`${config.nomis.apiUrl}/users/me`)
             .set('Authorization', `Bearer ${generateApiGatewayToken()}`)
             .set('Elite-Authorization', eliteAuthorisationToken);
 

--- a/server/config.js
+++ b/server/config.js
@@ -23,14 +23,6 @@ module.exports = {
         database: get('DB_NAME', 'licences')
     },
 
-    licences: {
-        apiUrl: get('LICENCES_API_URL', 'http://localhost:3001'),
-        timeout: {
-            response: 2000,
-            deadline: 2500
-        }
-    },
-
     nomis: {
         apiUrl: get('NOMIS_API_URL', 'http://localhost:9090/elite2api'),
         apiGatewayToken: get('NOMIS_GW_TOKEN', 'dummy'),

--- a/server/config.js
+++ b/server/config.js
@@ -32,8 +32,7 @@ module.exports = {
     },
 
     nomis: {
-        apiUrl: get('NOMIS_API_URL', 'http://localhost:9090/'),
-        apiRoot: get('NOMIS_API_ROOT', 'elite2api'),
+        apiUrl: get('NOMIS_API_URL', 'http://localhost:9090/elite2api'),
         apiGatewayToken: get('NOMIS_GW_TOKEN', 'dummy'),
         apiGatewayPrivateKey: new Buffer(get('NOMIS_GW_KEY', 'dummy'), 'base64').toString('ascii'),
         timeout: {

--- a/server/data/healthcheck.js
+++ b/server/data/healthcheck.js
@@ -2,7 +2,6 @@ const config = require('../config.js');
 const {getCollection} = require('./dataAccess/dbMethods');
 const logger = require('../../log.js');
 
-const url = require('url');
 const superagent = require('superagent');
 
 const generateApiGatewayToken = require('../authentication/apiGateway');
@@ -24,7 +23,7 @@ function nomisApiCheck() {
         const gwToken = process.env.NODE_ENV === 'test' ? 'dummy' : `Bearer ${generateApiGatewayToken()}`;
 
         superagent
-            .get(url.resolve(`${config.nomis.apiUrl}`, '/api/info/health'))
+            .get(`${config.nomis.apiUrl}/info/health`)
             .set('Authorization', gwToken)
             .timeout({
                 response: 2000,

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -2,7 +2,6 @@ const config = require('../config');
 const logger = require('../../log.js');
 
 const superagent = require('superagent');
-const url = require('url');
 
 const generateApiGatewayToken = require('../authentication/apiGateway');
 
@@ -12,40 +11,39 @@ const timeoutSpec = {
 };
 
 const apiUrl = config.nomis.apiUrl;
-const apiRoot = config.nomis.apiRoot;
 
 module.exports = function(token) {
     return {
         getUpcomingReleasesFor: function(nomisIds) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/offender-releases`);
+            const path = `${apiUrl}/offender-releases`;
             const query = {offenderNo: nomisIds};
             const headers = {'Page-Count': nomisIds.length};
             return nomisGet(path, query, token, headers);
         },
 
         getBookings: function(nomisId) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/bookings`);
+            const path = `${apiUrl}/bookings`;
             const query = {query: `offenderNo:eq:'${nomisId}'`};
             return nomisGet(path, query, token);
         },
 
         getBooking: function(bookingId) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/bookings/${bookingId}`);
+            const path = `${apiUrl}/bookings/${bookingId}`;
             return nomisGet(path, '', token);
         },
 
         getSentenceDetail: function(bookingId) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/bookings/${bookingId}/sentenceDetail`);
+            const path = `${apiUrl}/bookings/${bookingId}/sentenceDetail`;
             return nomisGet(path, '', token);
         },
 
         getImageInfo: function(imageId) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/images/${imageId}`);
+            const path = `${apiUrl}/images/${imageId}`;
             return nomisGet(path, '', token);
         },
 
         getDischargeAddress: function(nomisId) {
-            const path = url.resolve(`${apiUrl}`, `${apiRoot}/dischargeAddress`);
+            const path = `${apiUrl}/dischargeAddress`;
             const query = {nomisId: `${nomisId}`};
             return nomisGet(path, query, token);
         }

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -21,7 +21,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/offender-releases?offenderNo=a`)
+                .get(`/offender-releases?offenderNo=a`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getUpcomingReleasesFor('a', 'token')).to.eventually.eql({key: 'value'});
@@ -29,7 +29,7 @@ describe('nomisClient', function() {
 
         it('should set the page-count header to match the number of offenders', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/offender-releases?offenderNo=a&offenderNo=b&offenderNo=c`)
+                .get(`/offender-releases?offenderNo=a&offenderNo=b&offenderNo=c`)
                 .reply(function(uri, requestBody) {
                     // The documented way to specify request headers doesn't work so this is a workaround
                     if (this.req.headers['page-count'] === 3) { // eslint-disable-line
@@ -44,7 +44,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/offender-releases?offenderNo=a`)
+                .get(`/offender-releases?offenderNo=a`)
                 .reply(500);
 
             return expect(nomisClient.getUpcomingReleasesFor('a', 'token')).to.be.rejected();
@@ -55,7 +55,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings?query=offenderNo%3Aeq%3A%27A1235HG%27`)
+                .get(`/bookings?query=offenderNo%3Aeq%3A%27A1235HG%27`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getBookings('A1235HG', 'token')).to.eventually.eql({key: 'value'});
@@ -63,7 +63,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings?query=offenderNo%3Aeq%3AA1235HG`)
+                .get(`/bookings?query=offenderNo%3Aeq%3AA1235HG`)
                 .reply(500);
 
             return expect(nomisClient.getBookings('A1235HG', 'token')).to.be.rejected();
@@ -74,7 +74,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings/1`)
+                .get(`/bookings/1`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getBooking('1', 'token')).to.eventually.eql({key: 'value'});
@@ -82,7 +82,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings/1`)
+                .get(`/bookings/1`)
                 .reply(500);
 
             return expect(nomisClient.getBooking('1', 'token')).to.be.rejected();
@@ -93,7 +93,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings/1/sentenceDetail`)
+                .get(`/bookings/1/sentenceDetail`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getSentenceDetail('1', 'token')).to.eventually.eql({key: 'value'});
@@ -101,7 +101,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/bookings/1/sentenceDetail`)
+                .get(`/bookings/1/sentenceDetail`)
                 .reply(500);
 
             return expect(nomisClient.getSentenceDetail('1', 'token')).to.be.rejected();
@@ -112,7 +112,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/images/1`)
+                .get(`/images/1`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getImageInfo('1', 'token')).to.eventually.eql({key: 'value'});
@@ -120,7 +120,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/images/1`)
+                .get(`/images/1`)
                 .reply(500);
 
             return expect(nomisClient.getImageInfo('1', 'token')).to.be.rejected();
@@ -131,7 +131,7 @@ describe('nomisClient', function() {
 
         it('should return data from api', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/dischargeAddress?nomisId=a`)
+                .get(`/dischargeAddress?nomisId=a`)
                 .reply(200, {key: 'value'});
 
             return expect(nomisClient.getDischargeAddress('a', 'token')).to.eventually.eql({key: 'value'});
@@ -139,7 +139,7 @@ describe('nomisClient', function() {
 
         it('should reject if api fails', () => {
             fakeNomis
-                .get(`/${config.nomis.apiRoot}/dischargeAddress?nomisId=a`)
+                .get(`/dischargeAddress?nomisId=a`)
                 .reply(500);
 
             return expect(nomisClient.getDischargeAddress('a', 'token')).to.be.rejected();


### PR DESCRIPTION
Moved api url and path into one config prop to avoid having to wait for webops to update terraform to give us an extra env var