### PR TITLE
Rely on a valid gateway token instead of using a dummy in test env

### DIFF
--- a/server/data/healthcheck.js
+++ b/server/data/healthcheck.js
@@ -20,7 +20,7 @@ function dbCheck() {
 function nomisApiCheck() {
     return new Promise((resolve, reject) => {
 
-        const gwToken = process.env.NODE_ENV === 'test' ? 'dummy' : `Bearer ${generateApiGatewayToken()}`;
+        const gwToken = `Bearer ${generateApiGatewayToken()}`;
 
         superagent
             .get(`${config.nomis.apiUrl}/info/health`)

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -60,7 +60,7 @@ module.exports = function(token) {
 async function nomisGet(path, query, token, headers = {}) {
 
     try {
-        const gwToken = process.env.NODE_ENV === 'test' ? 'dummy' : `Bearer ${generateApiGatewayToken()}`;
+        const gwToken = `Bearer ${generateApiGatewayToken()}`;
 
         const result = await superagent
             .get(path)


### PR DESCRIPTION
Changing node_env to test instead of prod broke login because of using a dummy gateway token in test to avoid an error if you try to sign the token when it isn't in the correct format.

As long as we have a correctly formatted token in the NOMIS_GW_TOKEN env var that error won't occur and we don't need a special case for test mode. Without that special case, the login token will be valid even in test mode.