### PR TITLE
Stop passing role manually

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -151,7 +151,7 @@ module.exports = function createApp({
     app.locals.asset_path = '/public/';
 
     function addTemplateVariables(req, res, next) {
-        res.locals.profile = req.user;
+        res.locals.user = req.user;
         next();
     }
 

--- a/server/authentication/signIn.js
+++ b/server/authentication/signIn.js
@@ -36,8 +36,7 @@ async function signIn(username, password) {
         const roleCode = role.roleCode.substring(role.roleCode.lastIndexOf('_') + 1);
 
         logger.info(`Elite2 profile success for [${username}] with role  [${roleCode}]`);
-        return {...profileResult.body, token: eliteAuthorisationToken, role, roleCode, username};
-
+        return {...profileResult.body, token: eliteAuthorisationToken, role: roleCode, username};
     } catch (error) {
         logger.error(`Elite 2 login error [${username}]:`, error.stack);
         throw error;

--- a/server/routes/caseList.js
+++ b/server/routes/caseList.js
@@ -9,7 +9,7 @@ module.exports = function({logger, caseListService, authenticationMiddleware}) {
         logger.debug('GET /caseList');
         const hdcEligible = await caseListService.getHdcCaseList(req.user);
 
-        return res.render('caseList/index', {hdcEligible, role: req.user.roleCode});
+        return res.render('caseList/index', {hdcEligible});
     }));
 
     return router;

--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -15,7 +15,7 @@ module.exports = function({logger, licenceService, authenticationMiddleware}) {
     router.get('/:nomisId', asyncMiddleware(async (req, res) => {
         logger.debug('GET /send');
 
-        res.render(`send/${req.user.roleCode}`, {nomisId: req.params.nomisId});
+        res.render('send/', {nomisId: req.params.nomisId});
     }));
 
     router.post('/omu/', asyncMiddleware(async (req, res) => {

--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -15,7 +15,7 @@ module.exports = function({logger, licenceService, authenticationMiddleware}) {
     router.get('/:nomisId', asyncMiddleware(async (req, res) => {
         logger.debug('GET /send');
 
-        res.render('send/', {nomisId: req.params.nomisId});
+        res.render('send', {nomisId: req.params.nomisId});
     }));
 
     router.post('/omu/', asyncMiddleware(async (req, res) => {

--- a/server/routes/sent.js
+++ b/server/routes/sent.js
@@ -17,7 +17,7 @@ module.exports = function({logger, licenceService, authenticationMiddleware}) {
 
         const agency = await licenceService.getEstablishment(req.params.nomisId);
 
-        res.render('sent/', {agency});
+        res.render('sent', {agency});
     }));
 
 

--- a/server/routes/sent.js
+++ b/server/routes/sent.js
@@ -17,7 +17,7 @@ module.exports = function({logger, licenceService, authenticationMiddleware}) {
 
         const agency = await licenceService.getEstablishment(req.params.nomisId);
 
-        res.render(`sent/${req.user.roleCode}`, {agency});
+        res.render('sent/', {agency});
     }));
 
 

--- a/server/services/caseListService.js
+++ b/server/services/caseListService.js
@@ -32,7 +32,7 @@ async function getCaseList(nomisClient, licenceClient, user) {
         DM: nomisClient.getHdcEligiblePrisoners
     };
 
-    return asyncCaseRetrievalMethod[user.roleCode]();
+    return asyncCaseRetrievalMethod[user.role]();
 }
 
 function getROCaseList(nomisClient, licenceClient, user) {

--- a/server/views/caseList/index.pug
+++ b/server/views/caseList/index.pug
@@ -3,8 +3,8 @@ extends ../layout
 block content
     h1#pageHeading.heading-large HDC eligible prisoners
 
-    if role === 'CA'
+    if user.role === 'CA'
         include CATable
 
-    if role === 'RO'
+    if user.role === 'RO'
         include ROTable

--- a/server/views/layout.pug
+++ b/server/views/layout.pug
@@ -47,9 +47,9 @@ html(lang="en")
                         a(href="https://www.gov.uk", title="Go to the GOV.UK homepage", id="logo", class="content hmppslogo")
                             img(src="/public/images/hmpps_logo_small.png", width="54", height="48", alt="")
                             span  HMPPS
-                if profile
+                if user
                     div(id="header-user")
-                        span.bold #{profile.firstName}, #{profile.lastName} &nbsp;&nbsp;|&nbsp;&nbsp;
+                        span.bold #{user.firstName}, #{user.lastName} &nbsp;&nbsp;|&nbsp;&nbsp;
                         a(href="/logout") Logout
 
         main.pure-g(role="main")

--- a/test/routes/licenceConditionsTest.js
+++ b/test/routes/licenceConditionsTest.js
@@ -34,7 +34,7 @@ const conditionsServiceStub = {
 const testUser = {
     staffId: 'my-staff-id',
     token: 'my-token',
-    roleCode: 'OM'
+    roleCode: 'CA'
 };
 
 const app = appSetup(createLicenceConditionsRoute({

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -45,17 +45,16 @@ const testUser = {
 };
 
 const app = appSetup(createTaskListRoute({
-        prisonerService: serviceStub,
-        licenceService: licenceServiceStub,
-        logger: loggerStub,
-        authenticationMiddleware
-    }
-), testUser);
+    prisonerService: serviceStub,
+    licenceService: licenceServiceStub,
+    logger: loggerStub,
+    authenticationMiddleware
+}), testUser);
 
 describe('GET /taskList/:prisonNumber', () => {
 
     afterEach(() => {
-       sandbox.reset();
+        sandbox.reset();
     });
 
     it('should call getPrisonerDetails from prisonerDetailsService', () => {
@@ -104,16 +103,18 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('when prisoner is not excluded', () => {
         it('should display opt out form link', () => {
-            licenceServiceStub.getLicence.resolves({licence: {
-                eligibility: {
-                    excluded: {
-                        decision: 'No'
-                    },
-                    suitability: {
-                        decision: 'No'
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    eligibility: {
+                        excluded: {
+                            decision: 'No'
+                        },
+                        suitability: {
+                            decision: 'No'
+                        }
                     }
                 }
-            }});
+            });
 
             return request(app)
                 .get('/1233456')
@@ -126,10 +127,14 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('when prisoner is ineligible', () => {
         it('should not display link to opt out when excluded', () => {
-            licenceServiceStub.getLicence.resolves({licence: {eligibility: {
-                excluded: 'No',
-                unsuitable: 'Yes'
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    eligibility: {
+                        excluded: 'No',
+                        unsuitable: 'Yes'
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')
@@ -140,10 +145,14 @@ describe('GET /taskList/:prisonNumber', () => {
         });
 
         it('should not display link to opt out when unsuitable', () => {
-            licenceServiceStub.getLicence.resolves({licence: {eligibility: {
-                excluded: 'Yes',
-                unsuitable: 'No'
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    eligibility: {
+                        excluded: 'Yes',
+                        unsuitable: 'No'
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')
@@ -154,10 +163,14 @@ describe('GET /taskList/:prisonNumber', () => {
         });
 
         it('should not display link to opt out when unsuitable and excluded', () => {
-            licenceServiceStub.getLicence.resolves({licence: {eligibility: {
-                excluded: 'Yes',
-                unsuitable: 'Yes'
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    eligibility: {
+                        excluded: 'Yes',
+                        unsuitable: 'Yes'
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')
@@ -170,9 +183,13 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('when prisoner has opted out', () => {
         it('should display that user has opted out', () => {
-            licenceServiceStub.getLicence.resolves({licence: {proposedAddress: {
-                optOut: {decision: 'Yes'}
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    proposedAddress: {
+                        optOut: {decision: 'Yes'}
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')
@@ -185,9 +202,13 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('when address has been submitted', () => {
         it('should display that it has been submitted', () => {
-            licenceServiceStub.getLicence.resolves({licence: {proposedAddress: {
-                optOut: {licenceStatus: 'ADDRESS_SUBMITTED'}
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    proposedAddress: {
+                        optOut: {licenceStatus: 'ADDRESS_SUBMITTED'}
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')
@@ -200,9 +221,13 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('when bass has been requested', () => {
         it('should display that it has been requested', () => {
-            licenceServiceStub.getLicence.resolves({licence: {proposedAddress: {
-                bassReferral: {decision: 'Yes'}
-            }}});
+            licenceServiceStub.getLicence.resolves({
+                licence: {
+                    proposedAddress: {
+                        bassReferral: {decision: 'Yes'}
+                    }
+                }
+            });
 
             return request(app)
                 .get('/1233456')

--- a/test/services/caseListServiceTest.js
+++ b/test/services/caseListServiceTest.js
@@ -43,13 +43,13 @@ describe('caseListService', () => {
     const user = {
         staffId: '123',
         token: 'token',
-        roleCode: 'CA'
+        role: 'CA'
     };
 
     const ROUser = {
         staffId: '123',
         token: 'token',
-        roleCode: 'RO'
+        role: 'RO'
     };
 
     const nomisClientBuilder = sandbox.stub().returns(nomisClient);

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -15,7 +15,7 @@ const testUser = {
     lastName: 'last',
     staffId: 'id',
     token: 'token',
-    roleCode: 'CA'
+    role: 'CA'
 };
 
 module.exports = {
@@ -30,8 +30,10 @@ module.exports = {
 
         app.use((req, res, next) => {
             req.user = user;
+            res.locals.user = user;
             next();
         });
+
         app.use(bodyParser.json());
         app.use(bodyParser.urlencoded({extended: false}));
         app.use(route);


### PR DESCRIPTION
In a couple of places we were passing role to the view but it's already there.

I've changed it from `profile.roleCode` to `user.role` so in any view you can always do user.role