### PR TITLE
Allow for missing prison address info without failing

### DIFF
--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -32,7 +32,7 @@ module.exports = function({logger, licenceService, prisonerService, authenticati
     function getSubmissionTarget(nomisId, status, token) {
         switch (status) {
             case states.PROCESSING_RO:
-                return prisonerService.getEstablishment(nomisId, token);
+                return prisonerService.getEstablishmentForPrisoner(nomisId, token);
             default:
                 return null;
         }

--- a/server/services/prisonerService.js
+++ b/server/services/prisonerService.js
@@ -64,7 +64,7 @@ function createPrisonerService(nomisClientBuilder) {
             return getEstablishment(prisoner.agencyLocationId, token);
 
         } catch (error) {
-            logger.error('Error getting establishment info', error.stack);
+            logger.error('Error getting prisoner establishment', error.stack);
             throw error;
         }
     }
@@ -82,10 +82,10 @@ function createPrisonerService(nomisClientBuilder) {
 
             if(error.status === 404) {
                 logger.warn('Establishment not found: ' + agencyLocationId);
-                return;
+                return null;
             }
 
-            logger.error('Error getting establishment info', error.stack);
+            logger.error('Error getting establishment', error.stack);
             throw error;
         }
     }

--- a/server/services/prisonerService.js
+++ b/server/services/prisonerService.js
@@ -49,9 +49,9 @@ function createPrisonerService(nomisClientBuilder) {
         }
     }
 
-    async function getEstablishment(nomisId, token) {
+    async function getEstablishmentForPrisoner(nomisId, token) {
         try {
-            logger.info(`getEstablishment: ${nomisId}`);
+            logger.info(`getEstablishmentForPrisoner: ${nomisId}`);
 
             const nomisClient = nomisClientBuilder(token);
 
@@ -61,10 +61,7 @@ function createPrisonerService(nomisClientBuilder) {
                 return;
             }
 
-            const agencyLocationId = prisoner.agencyLocationId;
-            const establishment = await nomisClient.getEstablishment(agencyLocationId);
-
-            return formatObjectForView(establishment);
+            return getEstablishment(prisoner.agencyLocationId, token);
 
         } catch (error) {
             logger.error('Error getting establishment info', error.stack);
@@ -72,7 +69,28 @@ function createPrisonerService(nomisClientBuilder) {
         }
     }
 
-    return {getPrisonerDetails, getPrisonerImage, getEstablishment};
+    async function getEstablishment(agencyLocationId, token) {
+        try {
+            logger.info(`getEstablishment: ${agencyLocationId}`);
+
+            const nomisClient = nomisClientBuilder(token);
+            const establishment = await nomisClient.getEstablishment(agencyLocationId);
+
+            return formatObjectForView(establishment);
+
+        } catch (error) {
+
+            if(error.status === 404) {
+                logger.warn('Establishment not found: ' + agencyLocationId);
+                return;
+            }
+
+            logger.error('Error getting establishment info', error.stack);
+            throw error;
+        }
+    }
+
+    return {getPrisonerDetails, getPrisonerImage, getEstablishmentForPrisoner, getEstablishment};
 };
 
 

--- a/server/views/send/ROtoCA.pug
+++ b/server/views/send/ROtoCA.pug
@@ -3,10 +3,11 @@ div.pure-g
         h2.heading-large.midPaddingBottom Submit to the Prison Case Admin
         p.lede The HDC licence information is ready to be submitted to the Prison Case Admin or you can return to the task list and send it later.
 
-        if submissionTarget
-            p The information will be submitted to:
+        p The information will be submitted to:
 
-            div.bold Prison Case Admin
+        div.bold Prison Case Admin
+
+        if submissionTargets
             if submissionTarget.premise
                 div#premise.bold #{submissionTarget.premise}
             if submissionTarget.city
@@ -28,6 +29,9 @@ div.pure-g
             div.paddingBottom
                 if submissionTarget.email
                 | #{submissionTarget.email}
+
+        else
+            div.paddingBottom No prison address found
 
 div#continueBtns.pure-g.paddingBottom
     div.pure-u-1

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -19,7 +19,7 @@ const licenceServiceStub = {
 };
 
 const prisonerServiceStub = {
-    getEstablishment: sandbox.stub().returnsPromise().resolves({premise: 'HMP Blah'})
+    getEstablishmentForPrisoner: sandbox.stub().returnsPromise().resolves({premise: 'HMP Blah'})
 };
 
 const testUser = {
@@ -35,7 +35,7 @@ const app = appSetup(createSendRoute({
     authenticationMiddleware
 }), testUser);
 
-describe('Sending', () => {
+describe('Send:', () => {
 
     afterEach(() => {
         sandbox.reset();
@@ -53,8 +53,8 @@ describe('Sending', () => {
             return request(app)
                 .get('/123')
                 .expect(() => {
-                    expect(prisonerServiceStub.getEstablishment).to.be.calledOnce();
-                    expect(prisonerServiceStub.getEstablishment).to.be.calledWith('123', 'my-token');
+                    expect(prisonerServiceStub.getEstablishmentForPrisoner).to.be.calledOnce();
+                    expect(prisonerServiceStub.getEstablishmentForPrisoner).to.be.calledWith('123', 'my-token');
                 });
         });
 
@@ -65,7 +65,7 @@ describe('Sending', () => {
             return request(app)
                 .get('/123')
                 .expect(() => {
-                    expect(prisonerServiceStub.getEstablishment).to.not.be.called();
+                    expect(prisonerServiceStub.getEstablishmentForPrisoner).to.not.be.called();
                 });
         });
     });

--- a/test/services/prisonerServiceTest.js
+++ b/test/services/prisonerServiceTest.js
@@ -115,13 +115,13 @@ describe('prisonerDetailsService', () => {
         });
     });
 
-    describe('getEstablishment', () => {
+    describe('getEstablishmentForPrisoner', () => {
 
         it('should call the api with the nomis id', async () => {
 
             nomisClientMock.getHdcEligiblePrisoner.resolves(prisonerResponse);
 
-            await service.getEstablishment('123', 'token');
+            await service.getEstablishmentForPrisoner('123', 'token');
 
             expect(nomisClientMock.getHdcEligiblePrisoner).to.be.calledOnce();
             expect(nomisClientMock.getEstablishment).to.be.calledOnce();
@@ -130,14 +130,31 @@ describe('prisonerDetailsService', () => {
         });
 
         it('should return the result of the api call', () => {
-            return expect(service.getEstablishment('123'))
+            return expect(service.getEstablishmentForPrisoner('123'))
                 .to.eventually.eql(establishmentResponse);
         });
 
-        it('should throw if error in api', () => {
+        it('should throw if error in api when getting prisoner', () => {
             nomisClientMock.getHdcEligiblePrisoner.rejects(new Error('dead'));
+            return expect(service.getEstablishmentForPrisoner('123')).to.be.rejected();
+        });
 
-            return expect(service.getEstablishment('123')).to.be.rejected();
+        it('should throw if error in api when getting establishment', () => {
+            nomisClientMock.getHdcEligiblePrisoner.resolves(prisonerResponse);
+            nomisClientMock.getEstablishment.rejects(new Error('dead'));
+            return expect(service.getEstablishmentForPrisoner('123')).to.be.rejected();
+        });
+
+        it('should NOT throw but return null if 404 in api when getting establishment', () => {
+            nomisClientMock.getHdcEligiblePrisoner.resolves(prisonerResponse);
+            nomisClientMock.getEstablishment.rejects({status: 404});
+            return expect(service.getEstablishmentForPrisoner('123')).to.eventually.eql(null);
+        });
+
+        it('should throw if error in api when getting establishment if error ststus other than 404', () => {
+            nomisClientMock.getHdcEligiblePrisoner.resolves(prisonerResponse);
+            nomisClientMock.getEstablishment.rejects({status: 401});
+            return expect(service.getEstablishmentForPrisoner('123')).to.be.rejected();
         });
     });
 });


### PR DESCRIPTION
When looking up prison address, don't fail if the prison is not found because it might just be a missing prison record and shouldn't necessarily stop the whole thing the way it would if the prisoner wasn't found.