### PR TITLE
Update text

### DIFF
--- a/server/views/reporting/reportingInstructions.pug
+++ b/server/views/reporting/reportingInstructions.pug
@@ -7,7 +7,7 @@ block content
             a.link-back(href="javascript: window.history.back();") Back
 
     h2.heading-large Reporting instructions
-    p Enter the details of where the licensee should report
+    p Enter the details of where the offender should report
 
 
     form#reportingForm(method='POST')
@@ -19,7 +19,7 @@ block content
                 div.pure-g.largeMarginBottom.midPaddingBottom
                     div.pure-u-1.pure-u-md-4-5
                         div.form-group
-                            label.form-label(for="name") Name of person
+                            label.form-label(for="name") Name of person (or Duty Officer if unknown)
                             input#name.form-control(name="name" type="text" value=data.name)
 
                         div.form-group


### PR DESCRIPTION
1. Change licensee to offender

1. Instead of pre-filling a default of Duty Officer, which could easily be saved without making any effort to supply actual value and prevents making the field mandatory, after discussion with Eddie we've gone with a hint in the field label about using Duty Officer if not known. Then when we do validation it can be a mandatory field.
