### PR TITLE
moved address review items into array

### DIFF
--- a/server/routes/config/curfew.js
+++ b/server/routes/config/curfew.js
@@ -17,14 +17,15 @@ module.exports = {
                     No: '/hdc/taskList/'
                 }
             ],
-            path: '/hdc/curfew/addressSafety/'
+            path: '/hdc/curfew/addressSafety/',
+            pathAppend: 'addressIndex'
         }
     },
     addressSafety: {
         licenceMap: ['licence'],
         fields: [
             {deemedSafe: {}},
-            {reason: {dependentOn: 'deemedSafe', predicate: 'No'}}
+            {unsafeReason: {dependentOn: 'deemedSafe', predicate: 'No'}}
         ],
         nextPath: {
             decisions: [

--- a/server/utils/functionalHelpers.js
+++ b/server/utils/functionalHelpers.js
@@ -7,7 +7,8 @@ module.exports = {
     flatten,
     notAllValuesEmpty,
     allValuesEmpty,
-    getFirstArrayItems
+    getFirstArrayItems,
+    replaceArrayItem
 };
 
 // pass in your object and a path in array format
@@ -38,4 +39,8 @@ function notAllValuesEmpty(object) {
 
 function getFirstArrayItems(array, number) {
     return R.slice(0, number, array);
+}
+
+function replaceArrayItem(array, index, item) {
+    return R.update(parseInt(index))(item)(array);
 }

--- a/server/utils/routes.js
+++ b/server/utils/routes.js
@@ -4,23 +4,26 @@ module.exports = {
 
 function getPathFor({data, config}) {
     const {nextPath} = config;
+    const appendText = nextPath.pathAppend ? `${data[nextPath.pathAppend]}/` : '';
+    const defaultPath = `${nextPath.path}${appendText}`;
 
     if (!nextPath.decisions) {
-        return nextPath.path;
+        return defaultPath;
     }
 
     if (Array.isArray(nextPath.decisions)) {
         const path = determinePathFromDecisions({decisions: nextPath.decisions, data});
 
-        return path || nextPath.path;
+        return path || defaultPath;
     }
 
-    return getPathFromAnswer({nextPath: nextPath.decisions, data}) || nextPath.path;
+    return getPathFromAnswer({nextPath: nextPath.decisions, data}) || defaultPath;
 }
 
 function getPathFromAnswer({nextPath, data}) {
     const decidingValue = data[nextPath.discriminator];
-    return nextPath[decidingValue];
+    const path = nextPath[decidingValue];
+    return data[nextPath.pathAppend] ? `${path}${data[nextPath.pathAppend]}/` : path;
 }
 
 function determinePathFromDecisions({decisions, data}) {

--- a/server/views/curfew/addressSafety.pug
+++ b/server/views/curfew/addressSafety.pug
@@ -3,9 +3,7 @@ include ../proposedAddress/includes/addressDetail
 
 block content
 
-    -var review = data.curfew && data.curfew.curfewAddressReview ? data.curfew.curfewAddressReview : {}
-    -var addressSafety = data.curfew && data.curfew.addressSafety ? data.curfew.addressSafety : {}
-    -var address = data.proposedAddress && data.proposedAddress.curfewAddress ? data.proposedAddress.curfewAddress.preferred : {}
+    -var address = data.proposedAddress && data.proposedAddress.curfewAddress ? data.proposedAddress.curfewAddress.addresses[addressIndex] : {}
 
     div.pure-g.pure-u-1
         div.borderBottomLight
@@ -16,7 +14,7 @@ block content
             if address
                 p The following address has been requested by the offender.
 
-                +addressDetail('preferred', address, review)
+                +addressDetail('preferred', address)
 
         h3.heading-medium Decision
 
@@ -24,26 +22,27 @@ block content
         form(method="post")
             input(type="hidden" name="_csrf" value=csrfToken)
             input(type="hidden" name="nomisId" value=nomisId || '')
+            input(type="hidden" name="addressIndex" value=addressIndex || '')
             div.pure-g.largePaddingBottom
                 div.pure-u-1.pure-u-md-1-2
                     div.form-group
                         p Could this offender be managed safely at this address?
 
                         div.multiple-choice
-                            input#deemedSafeYes(type="radio" checked=addressSafety.deemedSafe === 'Yes' name="deemedSafe" value="Yes")
+                            input#deemedSafeYes(type="radio" checked=address.deemedSafe === 'Yes' name="deemedSafe" value="Yes")
                             label(for="deemedSafeYes") Yes
                         div.multiple-choice
-                            input#deemedSafePending(type="radio" checked=addressSafety.deemedSafe === pendingText name="deemedSafe" value=pendingText)
+                            input#deemedSafePending(type="radio" checked=address.deemedSafe === pendingText name="deemedSafe" value=pendingText)
                             label(for="deemedSafePending") #{pendingText}
                         div.multiple-choice(data-target="reasonForm")
-                            input#deemedSafeNo(type="radio" checked=addressSafety.deemedSafe === 'No' name="deemedSafe" value="No")
+                            input#deemedSafeNo(type="radio" checked=address.deemedSafe === 'No' name="deemedSafe" value="No")
                             label(for="deemedSafeNo") No
 
                         div#reasonForm.panel.panel-border-narrow.js-hidden
-                            label(for='reason') Please explain why you have made this decision
-                                textarea(name='reason' id='reason' class='form-control' rows='5')
-                                    if addressSafety.reason
-                                        | #{addressSafety.reason}
+                            label(for='unsafeReason') Please explain why you have made this decision
+                                textarea(name='unsafeReason' id='unsafeReason' class='form-control' rows='5')
+                                    if address.unsafeReason
+                                        | #{address.unsafeReason}
 
 
             include ../includes/saveAndReturn

--- a/server/views/curfew/curfewAddressReview.pug
+++ b/server/views/curfew/curfewAddressReview.pug
@@ -3,8 +3,7 @@ include ../proposedAddress/includes/addressDetail
 
 block content
 
-    -var review = data.curfew && data.curfew.curfewAddressReview ? data.curfew.curfewAddressReview : {}
-    -var address = data.proposedAddress && data.proposedAddress.curfewAddress ? data.proposedAddress.curfewAddress.addresses[0] : {}
+    -var address = data.proposedAddress && data.proposedAddress.curfewAddress ? data.proposedAddress.curfewAddress.addresses[addressIndex] : {}
 
     div.pure-g.pure-u-1
         div.borderBottomLight
@@ -22,35 +21,36 @@ block content
         form(method="post")
             input(type="hidden" name="_csrf" value=csrfToken)
             input(type="hidden" name="nomisId" value=nomisId || '')
+            input(type="hidden" name="addressIndex" value=addressIndex || '')
             div.pure-g.largePaddingBottom
                 div.pure-u-1.pure-u-sm-5-12.pure-g
                     div.form-group.inline
                         p Does the homeowner/landlord give informed consent to HDC at the address?
 
                         div.multiple-choice(data-target="consentForm")
-                            input#hdcConsentYes(type="radio" checked=review.consent === 'Yes' name="consent" value="Yes")
+                            input#hdcConsentYes(type="radio" checked=address.consent === 'Yes' name="consent" value="Yes")
                             label(for="hdcConsentYes") Yes
                         div.multiple-choice
-                            input#hdcConsentNo(type="radio" checked=review.consent === 'No' name="consent" value="No")
+                            input#hdcConsentNo(type="radio" checked=address.consent === 'No' name="consent" value="No")
                             label(for="hdcConsentNo") No
 
                         div#consentForm.panel.panel-border-narrow.js-hidden
                             div.form-group
                                 p Does the address have an electricity supply?
                                 div.multiple-choice
-                                    input#electricityYes(type="radio" checked=review.electricity === 'Yes' name="electricity" value="Yes")
+                                    input#electricityYes(type="radio" checked=address.electricity === 'Yes' name="electricity" value="Yes")
                                     label(for="electricityYes") Yes
                                 div.multiple-choice
-                                    input#electricityNo(type="radio" checked=review.electricity === 'No' name="electricity" value="No")
+                                    input#electricityNo(type="radio" checked=address.electricity === 'No' name="electricity" value="No")
                                     label(for="electricityNo") No
 
                             div.form-group
                                 p Was a home visit conducted in this case?
                                 div.multiple-choice
-                                    input#homeVisitConductedYes(type="radio" checked=review.homeVisitConducted === 'Yes' name="homeVisitConducted" value="Yes")
+                                    input#homeVisitConductedYes(type="radio" checked=address.homeVisitConducted === 'Yes' name="homeVisitConducted" value="Yes")
                                     label(for="homeVisitConductedYes") Yes
                                 div.multiple-choice
-                                    input#homeVisitConductedNo(type="radio" checked=review.homeVisitConducted === 'No' name="homeVisitConducted" value="No")
+                                    input#homeVisitConductedNo(type="radio" checked=address.homeVisitConducted === 'No' name="homeVisitConducted" value="No")
                                     label(for="homeVisitConductedNo") No
 
             include ../includes/formSubmit

--- a/server/views/proposedAddress/includes/addressDetail.pug
+++ b/server/views/proposedAddress/includes/addressDetail.pug
@@ -1,7 +1,4 @@
-mixin addressDetail(type, address, review, safety)
-
-    -var addressReview = review || {}
-    -var addressSafety = safety || {}
+mixin addressDetail(type, address)
 
     div.pure-g.smallPaddingBottom(id="addressDetails")
         div.pure-u-1.pure-u-sm-1-2.pure-g
@@ -52,32 +49,32 @@ mixin addressDetail(type, address, review, safety)
                     if address.cautionedAgainstResident
                         p.bold(id="cautioned-"+type) #{address.cautionedAgainstResident}
 
-    if addressReview.consent
+    if address.consent
         div.pure-g.largeMarginTop.paddingTop.smallPaddingBottom.borderTopLight
             div.pure-u-1-2
                 div.pure-u-md-4-5
                     | Does the homeowner/landlord give informed consent to HDC at the address?
-                    p.bold(id="consent-"+type) #{addressReview.consent}
+                    p.bold(id="consent-"+type) #{address.consent}
 
-            if(addressReview.consent === 'Yes')
+            if(address.consent === 'Yes')
                 div.pure-u-1-2
-                    if addressReview.electricity
+                    if address.electricity
                         div.pure-u-md-4-5.midPaddingBottom
                             | Does this address have an electricity supply?
-                            p.bold(id="electricity-"+type) #{addressReview.electricity}
+                            p.bold(id="electricity-"+type) #{address.electricity}
 
-                    if(addressReview.electricity === 'Yes')
-                        if addressReview.homeVisitConducted
+                    if(address.electricity === 'Yes')
+                        if address.homeVisitConducted
                             div.pure-u-md-4-5
                                 | Was a home visit conducted in this case?
-                                p.bold(id="homeVisit-"+type) #{addressReview.homeVisitConducted}
+                                p.bold(id="homeVisit-"+type) #{address.homeVisitConducted}
 
-            if(addressReview.consent === 'Yes' && addressReview.electricity !== 'No')
-                if addressSafety.deemedSafe
+            if(address.consent === 'Yes' && address.electricity !== 'No')
+                if address.deemedSafe
                     div.pure-u-1.largeMarginTop.paddingTop.borderTopLight
                         div.pure-u-md-4-5
                             | Could this offender be managed safely at this address?
-                            p.bold(id="deemedSafe-"+type) #{addressSafety.deemedSafe}
+                            p.bold(id="deemedSafe-"+type) #{address.deemedSafe}
 
             div.pure-u-1-2
 

--- a/server/views/review/includes/curfewAddress.pug
+++ b/server/views/review/includes/curfewAddress.pug
@@ -18,7 +18,7 @@ div.pure-g.borderBottomLight.midPaddingTopBottom
                     span#postCode-curfew.block.bold #{address.postCode}
             div.pure-u-1-2.alignRight
                 if (stage === 'PROCESSING_RO' && user.role === 'RO')
-                    a#addressEditLink(href="/hdc/curfew/curfewAddressReview/" + nomisId) Change these details
+                    a#addressEditLink(href="/hdc/curfew/curfewAddressReview/0/" + nomisId) Change these details
 
 div.pure-g.borderBottomLight.midPaddingTopBottom
     div.pure-u-1-2
@@ -67,10 +67,7 @@ div.pure-g.borderBottomLight.midPaddingTopBottom
             if address.cautionedAgainstResident
                 span#cautioned-curfew.bold #{address.cautionedAgainstResident}
 
-if data.curfew && data.curfew.curfewAddressReview
-    -var addressReview = data.curfew.curfewAddressReview || {}
-    -var addressSafety = data.curfew.addressSafety || {}
-
+if address.consent
     div.pure-g.borderBottomLight.midPaddingTopBottom
         div.pure-u-1-2
             div.pure-g
@@ -78,28 +75,28 @@ if data.curfew && data.curfew.curfewAddressReview
                     span Does the homeowner/landlord give informed consent to HDC at the address?
         div.pure-u-1-2
             div#dischargeHomeAddress
-                span#consent-curfew.bold #{addressReview.consent}
+                span#consent-curfew.bold #{address.consent}
 
-    if(addressReview.consent === 'Yes')
+    if(address.consent === 'Yes')
         div.pure-g.borderBottomLight.midPaddingTopBottom
             div.pure-u-1-2
                 span Does the address have an electricity supply?
             div.pure-u-1-2
-                if addressReview.electricity
-                    span#electricity-curfew.bold #{addressReview.electricity}
+                if address.electricity
+                    span#electricity-curfew.bold #{address.electricity}
 
-        if(addressReview.electricity === 'Yes')
+        if(address.electricity === 'Yes')
             div.pure-g.borderBottomLight.midPaddingTopBottom
                 div.pure-u-1-2
                     span Was a home visit conducted in this case?
                 div.pure-u-1-2
-                    span#homeVisit-curfew.bold #{addressReview.homeVisitConducted}
+                    span#homeVisit-curfew.bold #{address.homeVisitConducted}
 
             div.pure-g.borderBottomLight.midPaddingTopBottom
                 div.pure-u-1-2
                     span Could this offender be managed safely at address?
                 div.pure-u-1-2
-                    span#deemedSafe-curfew.bold #{addressSafety.deemedSafe}
+                    span#deemedSafe-curfew.bold #{address.deemedSafe}
 else
     div.pure-g.midPaddingTopBottom
         div.pure-u-1-2

--- a/server/views/taskList/curfewAddressTask.pug
+++ b/server/views/taskList/curfewAddressTask.pug
@@ -20,6 +20,6 @@ div.taskListItem
                     | Not yet approved
             div.pure-u-1-4
                 if user.role === 'RO'
-                    +proceed(licenceStatus.tasks.curfewAddressReview, 'UNSTARTED', 'Start', 'View', "/hdc/curfew/curfewAddressReview/" + prisonerInfo.offenderNo)
+                    +proceed(licenceStatus.tasks.curfewAddressReview, 'UNSTARTED', 'Start', 'View', "/hdc/curfew/curfewAddressReview/0/" + prisonerInfo.offenderNo)
                 else
                     a.taskListAction.center.button.button-secondary(href="/hdc/review/address/" + prisonerInfo.offenderNo) View

--- a/test/routes/curfewTest.js
+++ b/test/routes/curfewTest.js
@@ -32,9 +32,9 @@ describe('/hdc/curfew', () => {
         const routes = [
             {
                 url: '/curfew/curfewAddressReview/1',
-                body: {nomisId: 1},
+                body: {nomisId: 1, addressIndex: 5},
                 section: 'curfewAddressReview',
-                nextPath: '/hdc/curfew/addressSafety/1'
+                nextPath: '/hdc/curfew/addressSafety/5/1'
             },
             {
                 url: '/curfew/curfewAddressReview/1',
@@ -50,9 +50,9 @@ describe('/hdc/curfew', () => {
             },
             {
                 url: '/curfew/curfewAddressReview/1',
-                body: {nomisId: 1, consent: 'Yes'},
+                body: {nomisId: 1, consent: 'Yes', addressIndex: 5},
                 section: 'curfewAddressReview',
-                nextPath: '/hdc/curfew/addressSafety/1'
+                nextPath: '/hdc/curfew/addressSafety/5/1'
             },
             {
                 url: '/curfew/addressSafety/1',

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -320,7 +320,7 @@ describe('GET /taskList/:prisonNumber', () => {
                     .expect(200)
                     .expect('Content-Type', /html/)
                     .expect(res => {
-                        expect(res.text).to.include('/hdc/curfew/curfewAddressReview/noms">Start');
+                        expect(res.text).to.include('/hdc/curfew/curfewAddressReview/0/noms">Start');
                     });
 
             });
@@ -331,7 +331,13 @@ describe('GET /taskList/:prisonNumber', () => {
                 licenceServiceStub.getLicence.resolves({
                     status: 'PROCESSING_RO',
                     licence: {
-                        curfew: {curfewAddressReview: 'any'}
+                        proposedAddress: {
+                            curfewAddress: {
+                                addresses: [
+                                    {consent: 'Yes'}
+                                ]
+                            }
+                        }
                     }
                 });
                 return request(app)
@@ -339,7 +345,7 @@ describe('GET /taskList/:prisonNumber', () => {
                     .expect(200)
                     .expect('Content-Type', /html/)
                     .expect(res => {
-                        expect(res.text).to.include('/hdc/curfew/curfewAddressReview/noms">View');
+                        expect(res.text).to.include('/hdc/curfew/curfewAddressReview/0/noms">View');
                     });
 
             });

--- a/test/services/licenceServiceTest.js
+++ b/test/services/licenceServiceTest.js
@@ -808,4 +808,112 @@ describe('licenceService', () => {
             expect(output).to.eql(expectedLicence);
         });
     });
+
+    describe('updateAddress', () => {
+
+        const baseLicence = {
+            proposedAddress: {
+                curfewAddress: {
+                    addresses: [
+                        {postCode: 'pc1'},
+                        {postCode: 'pc2'}
+                    ]
+                }
+            }
+        };
+
+
+        it('should add form items to correct address', async () => {
+
+
+            const output = await service.updateAddress({
+                index: 1,
+                licence: baseLicence,
+                userInput: {newField: 'newField'},
+                fieldMap: [{newField: {}}]
+            });
+
+            const expectedOutput = {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {postCode: 'pc1'},
+                            {postCode: 'pc2', newField: 'newField'}
+                        ]
+                    }
+                }
+            };
+
+            expect(output).to.eql(expectedOutput);
+        });
+
+        it('should use the form config', async () => {
+            const output = await service.updateAddress({
+                index: 0,
+                licence: baseLicence,
+                userInput: {newField: 'newField', unwantedField: 'unwanted'},
+                fieldMap: [{newField: {}}]
+            });
+
+            const expectedOutput = {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {postCode: 'pc1', newField: 'newField'},
+                            {postCode: 'pc2'}
+                        ]
+                    }
+                }
+            };
+
+            expect(output).to.eql(expectedOutput);
+        });
+
+        it('should not change the rest of the licence', async () => {
+            const output = await service.updateAddress({
+                index: 0,
+                licence: {...baseLicence, otherfield: 'other'},
+                userInput: {newField: 'newField', unwantedField: 'unwanted'},
+                fieldMap: [{newField: {}}]
+            });
+
+            const expectedOutput = {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {postCode: 'pc1', newField: 'newField'},
+                            {postCode: 'pc2'}
+                        ]
+                    }
+                },
+                otherfield: 'other'
+            };
+
+            expect(output).to.eql(expectedOutput);
+        });
+
+        it('should update the saved licence', async () => {
+            await service.updateAddress({
+                nomisId: 1,
+                index: 0,
+                licence: baseLicence,
+                userInput: {newField: 'newField', unwantedField: 'unwanted'},
+                fieldMap: [{newField: {}}]
+            });
+
+            const expectedOutput = {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {postCode: 'pc1', newField: 'newField'},
+                            {postCode: 'pc2'}
+                        ]
+                    }
+                }
+            };
+
+            expect(licenceClient.updateLicence).to.be.calledOnce();
+            expect(licenceClient.updateLicence).to.be.calledWith(1, expectedOutput);
+        });
+    });
 });

--- a/test/utils/licenceStatusTest.js
+++ b/test/utils/licenceStatusTest.js
@@ -78,17 +78,16 @@ describe('getLicenceStatus', () => {
                     },
                     bassReferral: {
                         decision: 'Yes'
-                    }
-                },
-                curfew: {
-                    curfewAddressReview: {
-                        consent: 'Yes',
-                        electricity: 'Yes',
-                        homeVisitConducted: 'Yes'
-
                     },
-                    addressSafety: {
-                        deemedSafe: 'Yes'
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'Yes',
+                                deemedSafe: 'Yes'
+                            }
+                        ]
                     }
                 },
                 risk: {
@@ -183,11 +182,16 @@ describe('getLicenceStatus', () => {
                     },
                     bassReferral: {
                         decision: 'No'
-                    }
-                },
-                curfew: {
-                    curfewAddressReview: {
-                        consent: 'No'
+                    },
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'No',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'Yes',
+                                deemedSafe: 'Yes'
+                            }
+                        ]
                     }
                 },
                 finalChecks: {
@@ -306,17 +310,19 @@ describe('getLicenceStatus', () => {
             licence: {
                 proposedAddress: {
                     curfewAddress: {
-                        addressLine1: 'line'
+                        addresses: [
+                            {
+                                addressLine1: 'line',
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'Yes'
+                            }
+                        ]
                     }
                 },
                 licenceConditions: {
                     standard: {
                         additionalConditionsRequired: 'Yes'
-                    }
-                },
-                curfew: {
-                    curfewAddressReview: {
-                        consent: {}
                     }
                 },
                 risk: {
@@ -372,20 +378,20 @@ describe('getLicenceStatus', () => {
                         county: 'blah'
                     },
                     curfewAddress: {
-                        addressLine1: 'line',
-                        occupier: 'occupier',
-                        cautionedAgainstResident: 'Yes'
+                        addresses: [
+                            {
+                                addressLine1: 'line',
+                                occupier: 'occupier',
+                                cautionedAgainstResident: 'Yes',
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'Yes',
+                                deemedSafe: 'Yes'
+                            }
+                        ]
                     }
                 },
                 curfew: {
-                    curfewAddressReview: {
-                        consent: 'Yes',
-                        electricity: 'Yes',
-                        homeVisitConducted: 'Yes'
-                    },
-                    addressSafety: {
-                        deemedSafe: 'Yes'
-                    },
                     curfewHours: 'anything'
                 },
                 licenceConditions: {
@@ -447,15 +453,19 @@ describe('getLicenceStatus', () => {
         const licence = {
             status: 'PROCESSING_CA',
             licence: {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'Yes',
+                                deemedSafe: 'Yes - pending confirmation of risk management planning'
+                            }
+                        ]
+                    }
+                },
                 curfew: {
-                    curfewAddressReview: {
-                        consent: 'Yes',
-                        electricity: 'Yes',
-                        homeVisitConducted: 'Yes'
-                    },
-                    addressSafety: {
-                        deemedSafe: 'Yes - pending confirmation of risk management planning'
-                    },
                     curfewHours: 'anything'
                 }
             }
@@ -470,15 +480,52 @@ describe('getLicenceStatus', () => {
         const licence = {
             status: 'PROCESSING_CA',
             licence: {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'No',
+                                deemedSafe: 'Yes - pending confirmation of risk management planning'
+                            }
+                        ]
+                    }
+                },
                 curfew: {
-                    curfewAddressReview: {
-                        consent: 'Yes',
-                        electricity: 'Yes',
-                        homeVisitConducted: 'No'
-                    },
-                    addressSafety: {
-                        deemedSafe: 'Yes - pending confirmation of risk management planning'
-                    },
+                    curfewHours: 'anything'
+                }
+            }
+        };
+
+        const status = getLicenceStatus(licence);
+
+        expect(status.decisions.curfewAddressApproved).to.eql('approved');
+    });
+
+    it('should show address review APPROVED when any address is approved', () => {
+        const licence = {
+            status: 'PROCESSING_CA',
+            licence: {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'No',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'No',
+                                deemedSafe: 'Yes - pending confirmation of risk management planning'
+                            },
+                            {
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'No',
+                                deemedSafe: 'Yes - pending confirmation of risk management planning'
+                            }
+                        ]
+                    }
+                },
+                curfew: {
                     curfewHours: 'anything'
                 }
             }
@@ -493,15 +540,19 @@ describe('getLicenceStatus', () => {
         const licence = {
             status: 'PROCESSING_CA',
             licence: {
+                proposedAddress: {
+                    curfewAddress: {
+                        addresses: [
+                            {
+                                consent: 'Yes',
+                                electricity: 'Yes',
+                                homeVisitConducted: 'No',
+                                deemedSafe: 'No'
+                            }
+                        ]
+                    }
+                },
                 curfew: {
-                    curfewAddressReview: {
-                        consent: 'Yes',
-                        electricity: 'Yes',
-                        homeVisitConducted: 'No'
-                    },
-                    addressSafety: {
-                        deemedSafe: 'No'
-                    },
                     curfewHours: 'anything'
                 }
             }

--- a/test/utils/routesTest.js
+++ b/test/utils/routesTest.js
@@ -112,4 +112,54 @@ describe('getPathFor', () => {
             expect(path).to.equal('/bat');
         });
     });
+
+    context('data needs appening to url', () => {
+        it('appends to the default path when there is no match', () => {
+            const data = {
+                fooAnswer: 'Yes',
+                append: 'a'
+            };
+
+            const config = {
+                nextPath: {
+                    decisions: [
+                        {
+                            discriminator: 'fooAnswer',
+                            No: '/bar/'
+                        }
+                    ],
+                    path: '/bat/',
+                    pathAppend: 'append'
+                }
+            };
+
+            const path = getPathFor({data, config});
+
+            expect(path).to.equal('/bat/a/');
+        });
+
+        it('appends to the decision path when there is a match', () => {
+            const data = {
+                fooAnswer: 'No',
+                append: 'a'
+            };
+
+            const config = {
+                nextPath: {
+                    decisions: [
+                        {
+                            discriminator: 'fooAnswer',
+                            No: '/bar/',
+                            pathAppend: 'append'
+                        }
+                    ],
+                    path: '/bat'
+                }
+            };
+
+            const path = getPathFor({data, config});
+
+            expect(path).to.equal('/bar/a/');
+        });
+    });
 });


### PR DESCRIPTION
Moved the address review results into the array item.

When we know what requirements there are for an address then we could look at using one of the fields as a unique identifier rather than relying on array position.