### PR TITLE
Lic 227 pdf

### DIFF
--- a/server/services/config/pdfData.js
+++ b/server/services/config/pdfData.js
@@ -170,6 +170,7 @@ module.exports = {
         },
 
         CONDITIONS: {
+            noPlaceholder: true,
             paths: [['conditions']],
             displayName: 'Additional conditions',
             startIndex: 8,
@@ -180,6 +181,7 @@ module.exports = {
         },
 
         PSS: {
+            noPlaceholder: true,
             paths: [['pss']],
             displayName: 'Post-sentence supervision conditions',
             startIndex: 9,

--- a/server/services/config/pdfData.js
+++ b/server/services/config/pdfData.js
@@ -171,7 +171,22 @@ module.exports = {
 
         CONDITIONS: {
             paths: [['conditions']],
-            displayName: 'Additional conditions'
+            displayName: 'Additional conditions',
+            startIndex: 8,
+            divider: '\n\n',
+            terminator: ';',
+            filtered: ['ATTENDSAMPLE', 'ATTENDDEPENDENCY'],
+            filter: filtered => condition => !filtered.includes(condition.id)
+        },
+
+        PSS: {
+            paths: [['pss']],
+            displayName: 'Post-sentence supervision conditions',
+            startIndex: 9,
+            divider: '\n\n',
+            terminator: ';',
+            filtered: ['ATTENDSAMPLE', 'ATTENDDEPENDENCY'],
+            filter: filtered => condition => filtered.includes(condition.id)
         }
     }
 };

--- a/server/services/utils/pdfFormatter.js
+++ b/server/services/utils/pdfFormatter.js
@@ -43,7 +43,7 @@ const readValuesReducer = (allData, placeholder) => (summary, [key, spec]) => {
     }
 
     return mergeWithRight(summary, {
-        values: {[key]: placeholder},
+        values: {[key]: spec.noPlaceholder ? '' : placeholder},
         missing: {[key]: spec.displayName}
     });
 };

--- a/test/services/utils/pdfFormatterTest.js
+++ b/test/services/utils/pdfFormatterTest.js
@@ -128,6 +128,40 @@ describe('pdfFormatter', () => {
         expect(data.missing).to.not.have.property('CONDITIONS');
     });
 
+    it('should join conditions except exclusions', () => {
+
+        const licence = {
+            licenceConditions: [
+                {id: 'INCLUDED_1', content: [{text: 'first included condition'}]},
+                {id: 'ATTENDSAMPLE', content: [{text: 'excluded condition'}]},
+                {id: 'INCLUDED_2', content: [{variable: 'second included condition'}]}
+            ]
+        };
+        const expected = 'viii. first included condition;\n\nix. second included condition;';
+
+        const data = formatWith({licence: licence});
+
+        expect(data.values.CONDITIONS).to.eql(expected);
+        expect(data.missing).to.not.have.property('CONDITIONS');
+    });
+
+    it('should join PSS conditions only for inclusions', () => {
+
+        const licence = {
+            licenceConditions: [
+                {id: 'ATTENDSAMPLE', content: [{text: 'first PSS condition'}]},
+                {id: 'NOT_A_PSS_CONDITION', content: [{text: 'excluded condition'}]},
+                {id: 'ATTENDDEPENDENCY', content: [{variable: 'second PSS condition'}]}
+            ]
+        };
+        const expected = 'ix. first PSS condition;\n\nx. second PSS condition;';
+
+        const data = formatWith({licence: licence});
+
+        expect(data.values.PSS).to.eql(expected);
+        expect(data.missing).to.not.have.property('PSS');
+    });
+
     it('should return placeholder when standard conditions only', () => {
 
         const licence = {
@@ -182,6 +216,7 @@ const allValuesEmpty = {
     OFF_NOMS: 'PLACEHOLDER',
     OFF_PHOTO: 'PLACEHOLDER',
     OFF_PNC: 'PLACEHOLDER',
+    PSS: 'PLACEHOLDER',
     REPORTING_ADDRESS: 'PLACEHOLDER',
     REPORTING_AT: 'PLACEHOLDER',
     REPORTING_NAME: 'PLACEHOLDER',
@@ -221,6 +256,7 @@ const displayNames = {
     OFF_NAME: 'Offender name',
     OFF_NOMS: 'Offender Noms ID',
     OFF_PNC: 'Offender PNC',
+    PSS: 'Post-sentence supervision conditions',
     REPORTING_ADDRESS: 'Reporting address',
     REPORTING_AT: 'Reporting at',
     REPORTING_NAME: 'Reporting name',

--- a/test/services/utils/pdfFormatterTest.js
+++ b/test/services/utils/pdfFormatterTest.js
@@ -162,7 +162,7 @@ describe('pdfFormatter', () => {
         expect(data.missing).to.not.have.property('PSS');
     });
 
-    it('should return placeholder when standard conditions only', () => {
+    it('should skip placeholder when standard conditions only', () => {
 
         const licence = {
             licenceConditions: {standard: {additionalConditionsRequired: 'No'}}
@@ -170,11 +170,13 @@ describe('pdfFormatter', () => {
 
         const data = formatWith({licence: licence});
 
-        expect(data.values.CONDITIONS).to.eql('PLACEHOLDER');
+        expect(data.values.CONDITIONS).to.eql('');
+        expect(data.values.PSS).to.eql('');
         expect(data.missing['CONDITIONS']).to.eql(displayNames['CONDITIONS']);
+        expect(data.missing['PSS']).to.eql(displayNames['PSS']);
     });
 
-    it('should return placeholder when additional conditions empty', () => {
+    it('should skip placeholder when additional conditions empty', () => {
 
         const licence = {
             licenceConditions: []
@@ -182,13 +184,15 @@ describe('pdfFormatter', () => {
 
         const data = formatWith({licence: licence});
 
-        expect(data.values.CONDITIONS).to.eql('PLACEHOLDER');
+        expect(data.values.CONDITIONS).to.eql('');
+        expect(data.values.PSS).to.eql('');
         expect(data.missing['CONDITIONS']).to.eql(displayNames['CONDITIONS']);
+        expect(data.missing['PSS']).to.eql(displayNames['PSS']);
     });
 });
 
 const allValuesEmpty = {
-    CONDITIONS: 'PLACEHOLDER',
+    CONDITIONS: '',
     CURFEW_ADDRESS: 'PLACEHOLDER',
     CURFEW_FIRST_FROM: 'PLACEHOLDER',
     CURFEW_FIRST_UNTIL: 'PLACEHOLDER',
@@ -216,7 +220,7 @@ const allValuesEmpty = {
     OFF_NOMS: 'PLACEHOLDER',
     OFF_PHOTO: 'PLACEHOLDER',
     OFF_PNC: 'PLACEHOLDER',
-    PSS: 'PLACEHOLDER',
+    PSS: '',
     REPORTING_ADDRESS: 'PLACEHOLDER',
     REPORTING_AT: 'PLACEHOLDER',
     REPORTING_NAME: 'PLACEHOLDER',


### PR DESCRIPTION
Don't use placeholder for conditions because they are optional so that part of the PDF can just be empty instead of having a placeholder like 'DATA MISSING' as used for the others