### PR TITLE
Don't show other tasks when address not approved

### DIFF
--- a/server/utils/licenceStatus.js
+++ b/server/utils/licenceStatus.js
@@ -356,7 +356,7 @@ function getCurfewAddressReviewState(licence) {
     const addresses = getIn(licence, ['proposedAddress', 'curfewAddress', 'addresses']);
 
     if (!addresses || isEmpty(addresses)) {
-        return {curfewAddressReview: taskStates.UNSTARTED, curfewAddressApproved: 'unfinished'};
+        return {curfewAddressReview: taskStates.UNSTARTED, curfewAddressApproved: 'unstarted'};
     }
 
     const lastAddress = lastItem(addresses);
@@ -377,7 +377,7 @@ function getCurfewAddressReviewState(licence) {
         return {curfewAddressReview: taskStates.STARTED, curfewAddressApproved: 'unfinished'};
     }
 
-    return {curfewAddressReview: taskStates.UNSTARTED, curfewAddressApproved: 'unfinished'};
+    return {curfewAddressReview: taskStates.UNSTARTED, curfewAddressApproved: 'unstarted'};
 }
 
 function getCurfewHoursState(licence) {

--- a/server/views/taskList/taskList.pug
+++ b/server/views/taskList/taskList.pug
@@ -34,12 +34,8 @@ block content
                     include caSubmitRefusalTask
 
             else
-
-                - var addressRejectedOrWithdrawn = licenceStatus.decisions.curfewAddressApproved === 'rejected' || licenceStatus.decisions.curfewAddressApproved === 'withdrawn'
-                - var addressReviewDone = licenceStatus.tasks.curfewAddressReview !== 'UNSTARTED'
-
                 include curfewAddressTask
-                if (addressReviewDone && !addressRejectedOrWithdrawn)
+                if (['unfinished', 'approved'].includes(licenceStatus.decisions.curfewAddressApproved))
                     include riskManagementTask
                     include curfewHoursTask
                     include additionalConditionsTask
@@ -67,12 +63,12 @@ block content
 
         if user.role === 'DM'
             include curfewAddressTask
-            if (licenceStatus.decisions.curfewAddressApproved !== 'rejected')
+            if (licenceStatus.decisions.curfewAddressApproved === 'approved')
                 include riskManagementTask
                 include curfewHoursTask
                 include additionalConditionsTask
                 include reportingInstructionsTask
-            include finalChecksTask
+                include finalChecksTask
             if licenceStatus.decisions.confiscationOrder
                 include postponementTask
 

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -916,7 +916,7 @@ describe('GET /taskList/:prisonNumber', () => {
         });
 
         context('Curfew address rejected', () => {
-            it('should display all other tasks', () => {
+            it('should NOT display all other tasks', () => {
                 licenceService.getLicence.resolves({
                     stage: 'PROCESSING_RO', licence: {
                         proposedAddress: {

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -718,13 +718,12 @@ describe('GET /taskList/:prisonNumber', () => {
             });
         });
 
-        context('additional condition task started', () => {
-            it('should display a view button for curfew address', () => {
+        context('additional conditions task started', () => {
+            it('should display a view button for additional conditions', () => {
+
                 licenceService.getLicence.resolves({
                     stage: 'PROCESSING_RO',
-                    licence: {
-                        licenceConditions: {standard: {additionalConditionsRequired: 'No'}}
-                    }
+                    licence: {licenceConditions: {standard: {additionalConditionsRequired: 'Yes'}}}
                 });
 
                 const app = createApp({licenceService, prisonerService}, roUser);
@@ -741,7 +740,12 @@ describe('GET /taskList/:prisonNumber', () => {
         });
 
         context('risk management task not started', () => {
-            it('should display a start button for additional conditions task', () => {
+            it('should display a start button for risk management task', () => {
+                licenceService.getLicence.resolves({
+                    stage: 'PROCESSING_RO',
+                    licence: {licenceConditions: {standard: {additionalConditionsRequired: 'No'}}}
+                });
+
                 const app = createApp({licenceService, prisonerService}, roUser);
 
                 return request(app)
@@ -759,9 +763,7 @@ describe('GET /taskList/:prisonNumber', () => {
             it('should display a view button for riskManagement', () => {
                 licenceService.getLicence.resolves({
                     stage: 'PROCESSING_RO',
-                    licence: {
-                        risk: {riskManagement: 'anything'}
-                    }
+                    licence: {risk: {riskManagement: 'anything'}}
                 });
 
                 const app = createApp({licenceService, prisonerService}, roUser);
@@ -856,7 +858,7 @@ describe('GET /taskList/:prisonNumber', () => {
             });
         });
 
-        context('When there is\'nt a confiscation order', () => {
+        context('When there is not a confiscation order', () => {
             it('should not display the postpone HDC button', () => {
                 licenceService.getLicence.resolves({
                     stage: 'APPROVAL', licence: {
@@ -877,6 +879,70 @@ describe('GET /taskList/:prisonNumber', () => {
                     .expect(res => {
                         expect(res.text).to.not.include('value="Postpone"');
                     });
+            });
+        });
+
+        context('Curfew address approved', () => {
+            it('should display all other tasks', () => {
+                licenceService.getLicence.resolves({
+                    stage: 'PROCESSING_RO', licence: {
+                        proposedAddress: {
+                            curfewAddress: {
+                                addresses: [{
+                                    consent: 'Yes',
+                                    electricity: 'Yes',
+                                    deemedSafe: 'Yes'
+                                }]
+                            }
+                        }
+                    }
+                });
+
+                const app = createApp({licenceService, prisonerService}, dmUser);
+
+                return request(app)
+                    .get('/123')
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(res => {
+                        expect(res.text).to.include('/hdc/review/risk/noms">View');
+                        expect(res.text).to.include('/hdc/review/curfewHours/noms">View');
+                        expect(res.text).to.include('/hdc/review/conditions/noms">View');
+                        expect(res.text).to.include('/hdc/review/reporting/noms">View');
+                        expect(res.text).to.include('Final checks');
+                    });
+
+            });
+        });
+
+        context('Curfew address rejected', () => {
+            it('should display all other tasks', () => {
+                licenceService.getLicence.resolves({
+                    stage: 'PROCESSING_RO', licence: {
+                        proposedAddress: {
+                            curfewAddress: {
+                                addresses: [{
+                                    consent: 'No'
+                                }]
+                            }
+                        }
+                    }
+                });
+
+                const app = createApp({licenceService, prisonerService}, dmUser);
+
+                return request(app)
+                    .get('/123')
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(res => {
+                        expect(res.text).not.to.include('/hdc/review/risk/noms">View');
+                        expect(res.text).not.to.include('/hdc/review/curfewHours/noms">View');
+                        expect(res.text).not.to.include('/hdc/review/conditions/noms">View');
+                        expect(res.text).not.to.include('/hdc/review/reporting/noms">View');
+                        expect(res.text).not.to.include('Final checks');
+                    });
+
             });
         });
     });

--- a/test/utils/licenceStatusTest.js
+++ b/test/utils/licenceStatusTest.js
@@ -724,7 +724,7 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.curfewAddressApproved).to.eql('rejected');
     });
 
-    it('should show address review UNFINISHED when there are active licences', () => {
+    it('should show address review UNSTARTED when there are active addresses', () => {
         const licence = {
             stage: 'PROCESSING_CA',
             licence: {
@@ -751,7 +751,8 @@ describe('getLicenceStatus', () => {
 
         const status = getLicenceStatus(licence);
 
-        expect(status.decisions.curfewAddressApproved).to.eql('unfinished');
+        expect(status.tasks.curfewAddressReview).to.eql(taskStates.UNSTARTED);
+        expect(status.decisions.curfewAddressApproved).to.eql('unstarted');
     });
 
     context('Eligibility', () => {


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LIC-498


In taskList, the original was
`if (addressReviewDone && !addressRejectedOrWithdrawn)` then show other tasks
where
`addressReviewDone = licenceStatus.tasks.curfewAddressReview !== 'UNSTARTED'`

The cases where the task is not UNSTARTED leaves where it is STARTED or DONE,
which includes outcomes 'withdrawn', 'rejected', 'unfinished', or 'approved'

We exclude the other tasks where 'rejected' or 'withdrawn', so that means we show the other tasks only when 'unfinished' or 'approved'.

I'm still not sure it can get the CA and be 'unfinished', but this change doesn't alter the behaviour in that case.

For the DM tasklist, we only show the other tasks when there is a suitable address, which can only be 'approved'