### PR TITLE
Lic 502

### DIFF
--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -43,6 +43,7 @@ module.exports = function({logger, licenceService, prisonerService, authenticati
     function getSubmissionTarget(nomisId, stage, username) {
         switch (stage) {
             case licenceStages.ELIGIBILITY:
+            case licenceStages.PROCESSING_CA:
                 return prisonerService.getComForPrisoner(nomisId, username);
             case licenceStages.PROCESSING_RO:
                 return prisonerService.getEstablishmentForPrisoner(nomisId, username);

--- a/server/routes/taskList.js
+++ b/server/routes/taskList.js
@@ -3,7 +3,7 @@ const {asyncMiddleware} = require('../utils/middleware');
 const path = require('path');
 const {getLicenceStatus} = require('../utils/licenceStatus');
 const {getStatusLabel} = require('../utils/licenceStatusLabels');
-const {getAllowedTransitions} = require('../utils/licenceStatusTransitions');
+const {getAllowedTransition} = require('../utils/licenceStatusTransitions');
 
 module.exports = function({logger, prisonerService, licenceService, authenticationMiddleware, audit}) {
     const router = express.Router();
@@ -24,12 +24,12 @@ module.exports = function({logger, prisonerService, licenceService, authenticati
         const licence = await licenceService.getLicence(nomisId);
 
         const licenceStatus = getLicenceStatus(licence);
-        const allowedTransitions = getAllowedTransitions(licenceStatus, req.user.role);
+        const allowedTransition = getAllowedTransition(licenceStatus, req.user.role);
         const statusLabel = getStatusLabel(licenceStatus, req.user.role);
 
         res.render('taskList/taskList', {
             licenceStatus,
-            allowedTransitions,
+            allowedTransition,
             statusLabel,
             prisonerInfo,
             nomisId

--- a/server/views/send/CAtoDM.pug
+++ b/server/views/send/CAtoDM.pug
@@ -10,5 +10,5 @@ div#continueBtns.pure-g.paddingBottom
             input(type="hidden" name="nomisId" value=nomisId)
             input(type="hidden" name="sender" value="CA")
             input(type="hidden" name="receiver" value="DM")
-            input(type="hidden" name="transitionType" value="CAtoDM")
+            input(type="hidden" name="transitionType" value=transitionType)
             include includes/sendButtons

--- a/server/views/send/CAtoDMRefusal.pug
+++ b/server/views/send/CAtoDMRefusal.pug
@@ -10,5 +10,5 @@ div#continueBtns.pure-g.paddingBottom
             input(type="hidden" name="nomisId" value=nomisId)
             input(type="hidden" name="sender" value="CA")
             input(type="hidden" name="receiver" value="DM")
-            input(type="hidden" name="transitionType" value="CAtoDMRefusal")
+            input(type="hidden" name="transitionType" value=transitionType)
             include includes/sendButtons

--- a/server/views/send/CAtoRO.pug
+++ b/server/views/send/CAtoRO.pug
@@ -17,7 +17,7 @@ div#continueBtns.pure-g.paddingBottom
             input(type="hidden" name="nomisId" value=nomisId)
             input(type="hidden" name="sender" value="CA")
             input(type="hidden" name="receiver" value="RO")
-            input(type="hidden" name="transitionType" value="CAtoRO")
+            input(type="hidden" name="transitionType" value=transitionType)
             if submissionTarget && submissionTarget.com
                 input(type="hidden" name="submissionTarget" value=submissionTarget.com)
             input#continueBtn.requiredButton.button.button-start(type="submit" value="Submit address")

--- a/server/views/send/DM.pug
+++ b/server/views/send/DM.pug
@@ -10,5 +10,5 @@ div#continueBtns.pure-g.paddingBottom
             input(type="hidden" name="nomisId" value=nomisId)
             input(type="hidden" name="sender" value="DM")
             input(type="hidden" name="receiver" value="CA")
-            input(type="hidden" name="transitionType" value="DMtoCA")
+            input(type="hidden" name="transitionType" value=transitionType)
             include includes/sendButtons

--- a/server/views/send/ROtoCA.pug
+++ b/server/views/send/ROtoCA.pug
@@ -40,7 +40,7 @@ div#continueBtns.pure-g.paddingBottom
             input(type="hidden" name="nomisId" value=nomisId)
             input(type="hidden" name="sender" value="RO")
             input(type="hidden" name="receiver" value="CA")
-            input(type="hidden" name="transitionType" value="ROtoCA")
+            input(type="hidden" name="transitionType" value=transitionType)
             if submissionTarget && submissionTarget.premise
                 input(type="hidden" name="submissionTarget" value=submissionTarget.premise)
             include includes/sendButtons

--- a/server/views/send/index.pug
+++ b/server/views/send/index.pug
@@ -8,16 +8,18 @@ block content
             include ../includes/personalDetailsSummary
 
     div.largePaddingBottom
-        if user.role == 'CA'
-            if allowedTransitions.caToDm
-                include CAtoDM.pug
-            else if allowedTransitions.caToDmRefusal
-                include CAtoDMRefusal.pug
-            else
-                include CAtoRO.pug
 
-        else if user.role == 'RO'
+        if transitionType === 'caToDm'
+            include CAtoDM.pug
+
+        else if transitionType === 'caToDmRefusal'
+            include CAtoDMRefusal.pug
+
+        else if transitionType === 'caToRo'
+            include CAtoRO.pug
+
+        else if transitionType === 'roToCa'
             include ROtoCA.pug
 
-        else if user.role == 'DM'
+        else if transitionType === 'dmToCa'
             include DM.pug

--- a/server/views/taskList/caSubmitTask.pug
+++ b/server/views/taskList/caSubmitTask.pug
@@ -9,7 +9,7 @@ div.largeMarginBottom.borderTop
 
     div.pure-g
         div.pure-u-3-4
-            if allowedTransitions.caToRo || allowedTransitions.caToDm
+            if allowedTransition === 'caToRo' || allowedTransition === 'caToDm'
                 | Ready to submit
             else if licenceStatus.decisions.postponed
                 | Submission unavailable - HDC application postponed
@@ -19,7 +19,7 @@ div.largeMarginBottom.borderTop
                 | Submission unavailable - Tasks not yet complete
 
         div.pure-u-1-4.center
-            if allowedTransitions.caToRo || allowedTransitions.caToDm
-                -var linkTarget = allowedTransitions.caToRo ? '/hdc/review/curfewAddress/' : '/hdc/send/';
+            if allowedTransition === 'caToRo' || allowedTransition === 'caToDm'
+                -var linkTarget = allowedTransition === 'caToRo' ? '/hdc/review/curfewAddress/' : '/hdc/send/';
                 a#continueBtn.taskListAction.center.button(href=linkTarget + prisonerInfo.offenderNo)
                     | Continue

--- a/server/views/taskList/roSubmitTask.pug
+++ b/server/views/taskList/roSubmitTask.pug
@@ -4,7 +4,7 @@ div.taskListItem.submit
     div.pure-g
         div#submitPcaStatus.pure-u-3-4
             if licenceStatus.stage === 'PROCESSING_RO'
-                if allowedTransitions.roToCa
+                if allowedTransition === 'roToCa'
                     | Ready to submit
                 else
                     | Tasks not yet complete
@@ -12,7 +12,6 @@ div.taskListItem.submit
                 | #{statusLabel}
         div.pure-u-1-4.center
             if licenceStatus.stage === 'PROCESSING_RO'
-                //- && allowedTransitions.roToCa
                 a.taskListAction.center.button(href="/hdc/review/licenceDetails/" + prisonerInfo.offenderNo)
                     | Continue
 

--- a/server/views/taskList/taskList.pug
+++ b/server/views/taskList/taskList.pug
@@ -28,9 +28,9 @@ block content
                 include eligibilityTask
                 if licenceStatus.decisions.eligible
                     include proposedAddressTask
-                if allowedTransitions.caToRo
+                if allowedTransition === 'caToRo'
                     include caSubmitTask
-                else if allowedTransitions.caToDmRefusal
+                else if allowedTransition === 'caToDmRefusal'
                     include caSubmitRefusalTask
 
             else
@@ -43,7 +43,7 @@ block content
                     include finalChecksTask
                 include postponementTask
                 include HDCRefusalTask
-                if allowedTransitions.caToDmRefusal
+                if allowedTransition === 'caToDmRefusal'
                     include caSubmitRefusalTask
                 else
                     include caSubmitTask

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -41,8 +41,21 @@ describe('Send:', () => {
                     });
             });
 
-            it('gets com details when submission is CA to RO', () => {
+            it('gets com details when submission is CA to RO in Eligibility stage', () => {
                 licenceService.getLicence.resolves({stage: 'ELIGIBILITY'});
+                const app = createApp({licenceService, prisonerService});
+
+                return request(app)
+                    .get('/123')
+                    .expect(() => {
+                        expect(prisonerService.getComForPrisoner).to.be.calledOnce();
+                        expect(prisonerService.getComForPrisoner).to.be.calledWith('123', 'my-username');
+                    });
+                expect(prisonerService.getEstablishmentForPrisoner).not.to.be.called();
+            });
+
+            it('gets com details when submission is CA to RO in Final Checks stage', () => {
+                licenceService.getLicence.resolves({stage: 'PROCESSING_CA'});
                 const app = createApp({licenceService, prisonerService});
 
                 return request(app)

--- a/test/utils/licenceStatusTransitionsTest.js
+++ b/test/utils/licenceStatusTransitionsTest.js
@@ -1,6 +1,6 @@
-const {getAllowedTransitions} = require('../../server/utils/licenceStatusTransitions');
+const {getAllowedTransition} = require('../../server/utils/licenceStatusTransitions');
 
-describe('getAllowedTransitions', () => {
+describe('getAllowedTransition', () => {
     it('should allow DM to CA for DM when approval task done', () => {
         const status = {
             stage: 'APPROVAL',
@@ -9,8 +9,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'DM');
-        expect(allowed.dmToCa).to.eql(true);
+        const allowed = getAllowedTransition(status, 'DM');
+        expect(allowed).to.eql('dmToCa');
     });
 
     it('should not allow DM to CA for DM when approval task not done', () => {
@@ -21,8 +21,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'DM');
-        expect(allowed.dmToCa).to.eql(false);
+        const allowed = getAllowedTransition(status, 'DM');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow RO to CA for RO when all RO tasks done', () => {
@@ -37,8 +37,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'RO');
-        expect(allowed.roToCa).to.eql(true);
+        const allowed = getAllowedTransition(status, 'RO');
+        expect(allowed).to.eql('roToCa');
     });
 
     it('should not allow RO to CA for RO when any RO tasks not done', () => {
@@ -53,8 +53,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'RO');
-        expect(allowed.roToCa).to.eql(false);
+        const allowed = getAllowedTransition(status, 'RO');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow RO to CA for RO when address rejected even when other tasks not done', () => {
@@ -72,8 +72,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'RO');
-        expect(allowed.roToCa).to.eql(true);
+        const allowed = getAllowedTransition(status, 'RO');
+        expect(allowed).to.eql('roToCa');
     });
 
     it('should not allow RO to CA for RO when address undecided', () => {
@@ -88,8 +88,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'RO');
-        expect(allowed.roToCa).to.eql(false);
+        const allowed = getAllowedTransition(status, 'RO');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow CA to RO in the ELIGIBILITY stage when all CA tasks done and decisions OK', () => {
@@ -105,16 +105,15 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
-                excluded: false,
+                excluded: null,
                 eligible: true
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToRo).to.eql(true);
-        expect(allowed.caToDm).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToRo');
     });
 
     it('should not allow CA to RO in the ELIGIBILITY stage when HDC has been opted out', () => {
@@ -134,8 +133,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToRo).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql(null);
     });
 
     it('should not allow CA to RO in the ELIGIBILITY stage when address has been rejected', () => {
@@ -151,12 +150,12 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                curfewAddressApproved: 'false'
+                curfewAddressApproved: 'null'
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToRo).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql(null);
     });
 
     it('should not allow CA to RO in the ELIGIBILITY stage when ineligible', () => {
@@ -172,16 +171,15 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
-                excluded: false,
-                eligible: false
+                excluded: null,
+                eligible: null
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToRo).to.eql(false);
-        expect(allowed.caToDmRefusal).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow CA to DM in the PROCESSING_CA stage when all CA tasks done and decisions OK', () => {
@@ -197,15 +195,15 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
-                excluded: false
+                excluded: null
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
+        const allowed = getAllowedTransition(status, 'CA');
 
-        expect(allowed.caToDm).to.eql(true);
+        expect(allowed).to.eql('caToDm');
     });
 
     it('should not allow CA to DM in the PROCESSING_CA when any CA tasks not done and decisions not OK', () => {
@@ -219,15 +217,15 @@ describe('getAllowedTransitions', () => {
                 bassReferral: 'DONE'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
                 excluded: true
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
+        const allowed = getAllowedTransition(status, 'CA');
 
-        expect(allowed.caToDm).to.eql(false);
+        expect(allowed).to.eql(null);
     });
 
     it('should allow CA to DM refusal when eligible and insufficient time', () => {
@@ -248,8 +246,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDmRefusal).to.eql(true);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToDmRefusal');
     });
 
     it('should allow CA to DM refusal when ineligble but insufficientTimeStop', () => {
@@ -266,12 +264,12 @@ describe('getAllowedTransitions', () => {
             },
             decisions: {
                 insufficientTimeStop: true,
-                eligible: false
+                eligible: null
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDmRefusal).to.eql(true);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToDmRefusal');
     });
 
     it('should not allow CA to DM refusal if ineligible without', () => {
@@ -287,13 +285,13 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                eligible: false,
+                eligible: null,
                 curfewAddressApproved: 'rejected'
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDmRefusal).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow CA to DM refusal if curfew address is rejected', () => {
@@ -314,8 +312,8 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDmRefusal).to.eql(true);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToDmRefusal');
     });
 
     it('should not allow CA to DM when HDC refused', () => {
@@ -331,15 +329,15 @@ describe('getAllowedTransitions', () => {
                 finalChecks: 'DONE'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
-                excluded: false,
+                excluded: null,
                 finalChecksRefused: true
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDm).to.eql(false);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql(null);
     });
 
     it('should allow CA to RO when address review has not been started', () => {
@@ -354,15 +352,15 @@ describe('getAllowedTransitions', () => {
                 curfewAddressReview: 'UNSTARTED'
             },
             decisions: {
-                postponed: false,
+                postponed: null,
                 curfewAddressApproved: 'approved',
-                excluded: false,
+                excluded: null,
                 finalChecksRefused: true
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToRo).to.eql(true);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToRo');
     });
 
     it('should allow CA to DM when address has been withdrawn', () => {
@@ -374,7 +372,7 @@ describe('getAllowedTransitions', () => {
             }
         };
 
-        const allowed = getAllowedTransitions(status, 'CA');
-        expect(allowed.caToDmRefusal).to.eql(true);
+        const allowed = getAllowedTransition(status, 'CA');
+        expect(allowed).to.eql('caToDmRefusal');
     });
 });


### PR DESCRIPTION
Send screen shows recipient details, obtained based on stage. We'd missed this when allowing CA to send to RO from final checks, instead of eligibility.

It makes more sense to get the recipient details based on the type of transition, since we're supporting more variations of sending, from different stages, for different reasons.